### PR TITLE
Rename gem to use use correct convention

### DIFF
--- a/govuk-message-queue-consumer.gemspec
+++ b/govuk-message-queue-consumer.gemspec
@@ -5,12 +5,12 @@ $:.unshift lib unless $:.include?(lib)
 require 'govuk_message_queue_consumer/version'
 
 Gem::Specification.new do |s|
-  s.name = "govuk-message-queue-consumer"
+  s.name = "govuk_message_queue_consumer"
   s.version = GovukMessageQueueConsumer::VERSION
   s.authors = ["GOV.UK Dev"]
   s.summary = "AMQP message queue consumption with GOV.UK conventions"
   s.description = "Avoid writing boilerplate code in order to consume messages from an AMQP message queue. Plug in queue configuration, and how to process each message."
-  s.homepage = "https://github.com/alphagov/govuk-message-queue-consumer"
+  s.homepage = "https://github.com/alphagov/govuk_message_queue_consumer"
   s.email = ["govuk-dev@digital.cabinet-office.gov.uk"]
 
   s.files = Dir.glob("lib/**/*") + %w{README.md Rakefile}

--- a/jenkins_branches.sh
+++ b/jenkins_branches.sh
@@ -8,7 +8,7 @@ VENV_PATH="${HOME}/venv/${JOB_NAME}"
 
 pip install -q ghtools
 
-REPO="alphagov/govuk-message-queue-consumer"
+REPO="alphagov/govuk_message_queue_consumer"
 gh-status "$REPO" "$GIT_COMMIT" pending -d "\"Build #${BUILD_NUMBER} is running on Jenkins\"" -u "$BUILD_URL" >/dev/null
 
 if ./jenkins.sh; then


### PR DESCRIPTION
From rubygems.org:

> USE UNDERSCORES FOR MULTIPLE WORDS
> If a class or module has multiple words, use underscores to separate
them. This matches the file the user will require, making it easier for
the user to start using your gem.

http://guides.rubygems.org/name-your-gem/

The convention is to use underscores for classes (`ruby_parser` -> `RubyParser`) and dashes for namespaces (`rdoc-data` -> `RDoc::Data`). This is also in our styleguide[1].

This correction didn't happen in the previous PR (#7) because I was under the impression that the convention was being broken consistently in our gems. After auditing half the gems owned by GOV.UK[1] it seems about 75% are correctly named, so we should keep this up.

[1] https://github.com/alphagov/styleguides/blob/master/rubygems.md#naming
[2] https://rubygems.org/profiles/govuk