### PR TITLE
Make test helpers easier to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,6 @@ configuration and an instance of a class that processes messages.
 The message format received by the message processor is found in
 `lib/govuk_message_queue_consumer/message.rb`
 
-Rspec shared examples are located in
-`lib/govuk_message_queue_consumer/support/shared_examples_for_message_processor.rb` to
-help ensure the message processor has the correct properties.
-
-
 ### Dependencies
 
 - **bunny**: to interact with RabbitMQ
@@ -68,6 +63,20 @@ class MyProcessor
 end
 ```
 
+#### Testing your processor
+
+This gem provides a test helper for your processor.
+
+```ruby
+require 'test_helper'
+require 'govuk_message_queue_consumer/test_helpers'
+
+describe MyProcessor do
+  it_behaves_like "a message queue processor"
+end
+```
+
+This will verify that your processor class implements the correct methods. You should add your own tests to verify its behaviour.
 
 ### Running the test suite
 

--- a/lib/govuk_message_queue_consumer/test_helpers.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers.rb
@@ -1,0 +1,1 @@
+require 'govuk_message_queue_consumer/test_helpers/shared_examples'

--- a/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
@@ -1,5 +1,4 @@
-RSpec.shared_examples "a message processor" do
-  # set the subject in your own tests
+RSpec.shared_examples "a message queue processor" do
   it "implements #process" do
     expect(subject).to respond_to(:process)
   end


### PR DESCRIPTION
This PR makes the test helpers easier to use by adding a complete example in the README. It also corrects the terminology to use "processor" consistently and makes the `require` less verbose.