### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.0.0
+
+- Rename the gem to `govuk_message_queue_consumer`
+- Make test helpers easier to use
+- Readme improvements
+- Initial release!
+
 # 0.9.1
 
 Bug fix:

--- a/lib/govuk_message_queue_consumer/version.rb
+++ b/lib/govuk_message_queue_consumer/version.rb
@@ -1,3 +1,3 @@
 module GovukMessageQueueConsumer
-  VERSION = '0.9.1'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
The first PR that uses this gem (https://github.com/alphagov/content-register/pull/28) is almost finished. Since that would mean this gem is used in production, semver dictates that we release 1.0.0.