### PR TITLE
Fix gemspec location

### DIFF
--- a/tasks/publish_gem.rake
+++ b/tasks/publish_gem.rake
@@ -2,6 +2,6 @@ require "gem_publisher"
 
 desc "Publish gem to RubyGems.org"
 task :publish_gem do |t|
-  gem = GemPublisher.publish_if_updated("message-queue-consumer.gemspec", :rubygems)
+  gem = GemPublisher.publish_if_updated("govuk_message_queue_consumer.gemspec", :rubygems)
   puts "Published #{gem}" if gem
 end


### PR DESCRIPTION
This was forgotten in the rename. Correcting it will allow `gem_publisher` to publish the gem.