### PR TITLE
Don't require active_support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ namespace :message_queue do
   desc "Run worker to consume messages from rabbitmq"
   task consumer: :environment do
     config = get_rabbitmq_configuration_hash
-    # ^ eg YAML.load_file(Rails.root.join('config', 'rabbitmq.yml'))[Rails.env]
+    # ^ eg YAML.load_file(Rails.root.join('config', 'rabbitmq.yml'))[Rails.env].with_indifferent_access
     GovukMessageQueueConsumer::Consumer.new(config, MyProcessor.new).run
   end
 end

--- a/govuk_message_queue_consumer.gemspec
+++ b/govuk_message_queue_consumer.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_dependency 'bunny', '~> 2.2.0'
-  s.add_dependency 'activesupport', '~> 4.0'
 
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'rspec', '~> 3.3.0'

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -1,4 +1,3 @@
-require 'active_support/core_ext/hash/indifferent_access'
 require 'bunny'
 
 module GovukMessageQueueConsumer
@@ -6,10 +5,9 @@ module GovukMessageQueueConsumer
     def initialize(config, processor)
       @processor = HeartbeatProcessor.new(processor)
 
-      @config = config.with_indifferent_access
-      @queue_name = @config.fetch(:queue)
-      @bindings = { @config.fetch(:exchange) => "#" }
-      @connection = Bunny.new(@config[:connection].symbolize_keys)
+      @queue_name = config.fetch(:queue)
+      @bindings = { config.fetch(:exchange) => "#" }
+      @connection = Bunny.new(config.fetch(:connection))
       @connection.start
     end
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -22,7 +22,7 @@ describe Consumer do
     end
 
     it "connects to rabbitmq" do
-      expected_options = rabbitmq_config['connection'].symbolize_keys # Bunny requires the keys to be symbols
+      expected_options = rabbitmq_config.fetch(:connection)
       expect(Bunny).to receive(:new).with(expected_options).and_return(rabbitmq_connecton)
       expect(rabbitmq_connecton).to receive(:start)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,16 +5,16 @@ include GovukMessageQueueConsumer
 module TestHelpers
   def rabbitmq_config
     {
-      "connection" => {
-        "hosts" => ["rabbitmq1.example.com", "rabbitmq2.example.com"],
-        "port" => 5672,
-        "vhost" => "/",
-        "user" => "a_user",
-        "pass" => "super secret",
-        "recover_from_connection_close" => true,
+      connection: {
+        hosts: ["rabbitmq1.example.com", "rabbitmq2.example.com"],
+        port: 5672,
+        vhost: "/",
+        user: "a_user",
+        pass: "super secret",
+        recover_from_connection_close: true,
       },
-      "queue" => "content_register",
-      "exchange" => "published_documents",
+      queue: "content_register",
+      exchange: "published_documents",
     }
   end
 


### PR DESCRIPTION
We should not depend on active_support because this app might be used in projects other than Rails. Instead of accepting both hashes and symbols, we will assume that the RabbitMQ config given consists only of keys. It will be the consumers' responsibility to provide the keys.

This specifically solves a problem with Panopticon being on Rails 3 and thus having a dependency conflict here.