### PR TITLE
Document why why only prefetch one message

### DIFF
--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -2,6 +2,15 @@ require 'bunny'
 
 module GovukMessageQueueConsumer
   class Consumer
+    # Only fetch one message at a time on the channel.
+    #
+    # By default, queues will grab messages eagerly, which reduces latency.
+    # However, that also means that if multiple workers are running one worker
+    # can starve another of work.  We're not expecting a high throughput on this
+    # queue, and a small bit of latency isn't a problem, so we fetch one at a
+    # time to share the work evenly.
+    NUMBER_OF_MESSAGES_TO_PREFETCH = 1
+
     def initialize(queue_name:, exchange:, processor:)
       @processor = HeartbeatProcessor.new(processor)
       @queue_name = queue_name
@@ -29,7 +38,7 @@ module GovukMessageQueueConsumer
 
     def setup_queue
       @channel = @connection.create_channel
-      @channel.prefetch(1) # only one unacked message at a time
+      @channel.prefetch(NUMBER_OF_MESSAGES_TO_PREFETCH)
       queue = @channel.queue(@queue_name, :durable => true)
       @bindings.each do |exchange_name, routing_key|
         exchange = @channel.topic(exchange_name, :passive => true)


### PR DESCRIPTION
This comment was taken from the email-alert-service and explains why we prefetch only one message: https://github.com/alphagov/email-alert-service/commit/30eb96fbd36363e7c79d72d505e69db84f20e1b8