### PR TITLE
Only add shared examples for RSpec projects

### DIFF
--- a/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
@@ -1,9 +1,11 @@
-RSpec.shared_examples "a message queue processor" do
-  it "implements #process" do
-    expect(subject).to respond_to(:process)
-  end
+if defined?(RSpec)
+  RSpec.shared_examples "a message queue processor" do
+    it "implements #process" do
+      expect(subject).to respond_to(:process)
+    end
 
-  it "accepts 1 argument for #process" do
-    expect(subject.method(:process).arity).to eq(1)
+    it "accepts 1 argument for #process" do
+      expect(subject.method(:process).arity).to eq(1)
+    end
   end
 end


### PR DESCRIPTION
Some projects don't use rspecm, but want to use the test helpers. To allow users to use `require 'govuk_message_queue_consumer/test_helpers'` regardless of test framework, we should wrap framework-specific code in a conditional.