### PR TITLE
Add GovukMessageQueueConsumer::MockMessage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Use environment variables for RabbitMQ configuration
 - Use keyword arguments for the `Consumer` setup
+- Add `GovukMessageQueueConsumer::MockMessage` for easy testing.
 
 # 1.0.0
 

--- a/README.md
+++ b/README.md
@@ -85,6 +85,23 @@ end
 
 This will verify that your processor class implements the correct methods. You should add your own tests to verify its behaviour.
 
+You can use `GovukMessageQueueConsumer::MockMessage` to test the processor behaviour. When using the mock, you can verify it acknowledged, retried or discarded. For example, with `MyProcessor` above:
+
+```ruby
+it "acks incoming messages" do
+  message = GovukMessageQueueConsumer::MockMessage.new
+
+  MyProcessor.new.process(message)
+
+  expect(message).to be_acked
+
+  # or if you use minitest:
+  assert message.acked?
+end
+```
+
+For more test cases [see the spec for the mock itself](/spec/mock_message_spec.rb).
+
 ### Running the test suite
 
 ```bash

--- a/lib/govuk_message_queue_consumer/test_helpers.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers.rb
@@ -1,1 +1,2 @@
 require 'govuk_message_queue_consumer/test_helpers/shared_examples'
+require 'govuk_message_queue_consumer/test_helpers/mock_message'

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -1,0 +1,26 @@
+module GovukMessageQueueConsumer
+  class MockMessage
+    attr_reader :acked, :retried, :discarded, :body_data, :delivery_info,
+                :headers, :body
+
+    alias :acked? :acked
+    alias :discarded? :discarded
+    alias :retried? :retried
+
+    def initialize(body_data = {})
+      @body_data = body_data
+    end
+
+    def ack
+      @acked = true
+    end
+
+    def retry
+      @retried = true
+    end
+
+    def discard
+      @discarded = true
+    end
+  end
+end

--- a/spec/mock_message_spec.rb
+++ b/spec/mock_message_spec.rb
@@ -1,0 +1,43 @@
+require_relative 'spec_helper'
+require_relative '../lib/govuk_message_queue_consumer/test_helpers/mock_message'
+
+describe GovukMessageQueueConsumer::MockMessage do
+  describe '#methods' do
+    it "implements the same methods as Message" do
+      mock = MockMessage.new(double)
+      real = Message.new(double, double, double)
+
+      expect(real.methods - mock.methods).to be_empty
+    end
+  end
+
+  describe '#ack' do
+    it "marks the message as acked" do
+      message = MockMessage.new
+
+      message.ack
+
+      expect(message).to be_acked
+    end
+  end
+
+  describe '#retry' do
+    it "marks the message as retried" do
+      message = MockMessage.new
+
+      message.retry
+
+      expect(message).to be_retried
+    end
+  end
+
+  describe '#discard' do
+    it "marks the message as discarded" do
+      message = MockMessage.new
+
+      message.discard
+
+      expect(message).to be_discarded
+    end
+  end
+end


### PR DESCRIPTION
`GovukMessageQueueConsumer::MockMessage` can be used to mock messages from RabbitMQ. Usage is documented in the README. When there are live examples, those will be added as a reference.

