### PR TITLE
Add option to specify a routing key

### DIFF
--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -11,10 +11,10 @@ module GovukMessageQueueConsumer
     # time to share the work evenly.
     NUMBER_OF_MESSAGES_TO_PREFETCH = 1
 
-    def initialize(queue_name:, exchange:, processor:)
+    def initialize(queue_name:, exchange:, processor:, routing_key: '#')
       @processor = HeartbeatProcessor.new(processor)
       @queue_name = queue_name
-      @bindings = { exchange => "#" }
+      @bindings = { exchange => routing_key }
       @connection = Bunny.new(RabbitMQConfig.new.from_environment)
       @connection.start
     end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -25,10 +25,16 @@ describe Consumer do
   end
 
   describe "running the consumer" do
-    it "binds the queue" do
-      expect(queue).to receive(:bind)
+    it "binds the queue to the all-routing key" do
+      expect(queue).to receive(:bind).with(nil, { routing_key: "#" })
 
       Consumer.new(queue_name: "some-queue", exchange: "my-exchange", processor: client_processor).run
+    end
+
+    it "binds the queue to a custom routing key" do
+      expect(queue).to receive(:bind).with(nil, { routing_key: "*.major" })
+
+      Consumer.new(queue_name: "some-queue", exchange: "my-exchange", processor: client_processor, routing_key: "*.major").run
     end
 
     it "calls the heartbeat processor when subscribing to messages" do


### PR DESCRIPTION
The `routing_key` is the pattern that is used to listen to specific messages. We publish messages to the content queue with `#{format}.#{update_type}`.

`email-alert-service` uses this to subscribe to major updates, because it only wants to send out emails when something significant changes.