### PR TITLE
Use default port for RabbitMQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ The consumer expects a number of environment variables to be present:
 
 ```
 RABBITMQ_HOSTS=rabbitmq1.example.com,rabbitmq2.example.com
-RABBITMQ_PORT=5672
 RABBITMQ_VHOST=/
 RABBITMQ_USER=a_user
 RABBITMQ_PASSWORD=a_super_secret

--- a/lib/govuk_message_queue_consumer/rabbitmq_config.rb
+++ b/lib/govuk_message_queue_consumer/rabbitmq_config.rb
@@ -5,7 +5,6 @@ class RabbitMQConfig
   def from_environment
     {
       hosts: fetch("RABBITMQ_HOSTS").split(','),
-      port: fetch("RABBITMQ_PORT").to_i,
       vhost: fetch("RABBITMQ_VHOST"),
       user: fetch("RABBITMQ_USER"),
       pass: fetch("RABBITMQ_PASSWORD"),

--- a/spec/rabbitmq_config_spec.rb
+++ b/spec/rabbitmq_config_spec.rb
@@ -4,14 +4,12 @@ RSpec.describe RabbitMQConfig do
   describe ".from_environment" do
     it "connects to rabbitmq with the correct environment variables" do
       ENV["RABBITMQ_HOSTS"] = "server-one,server-two"
-      ENV["RABBITMQ_PORT"] = "123"
       ENV["RABBITMQ_VHOST"] = "/"
       ENV["RABBITMQ_USER"] = "my_user"
       ENV["RABBITMQ_PASSWORD"] = "my_pass"
 
       expect(RabbitMQConfig.new.from_environment).to eql({
         hosts: ["server-one", "server-two"],
-        port: 123,
         vhost: "/",
         user: "my_user",
         pass: "my_pass",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ include GovukMessageQueueConsumer
 module TestHelpers
   def stub_environment_variables!
     ENV["RABBITMQ_HOSTS"] ||= ""
-    ENV["RABBITMQ_PORT"] ||= ""
     ENV["RABBITMQ_VHOST"] ||= "/"
     ENV["RABBITMQ_USER"] ||= "/"
     ENV["RABBITMQ_PASSWORD"] ||= "/"


### PR DESCRIPTION
5672 is the well-known default port for RabbitMQ. It is very unlikely this will ever be different across environment or applications. Bunny uses the port as a default, so this has no effect.

Bunny defaults: https://github.com/ruby-amqp/bunny/blob/master/lib/bunny/session.rb#L93