### PR TITLE
Handle invalid JSON

### DIFF
--- a/lib/govuk_message_queue_consumer.rb
+++ b/lib/govuk_message_queue_consumer.rb
@@ -1,5 +1,6 @@
 require 'govuk_message_queue_consumer/version'
 require 'govuk_message_queue_consumer/heartbeat_processor'
+require 'govuk_message_queue_consumer/json_processor'
 require 'govuk_message_queue_consumer/message'
 require 'govuk_message_queue_consumer/consumer'
 require 'govuk_message_queue_consumer/rabbitmq_config'

--- a/lib/govuk_message_queue_consumer/json_processor.rb
+++ b/lib/govuk_message_queue_consumer/json_processor.rb
@@ -1,11 +1,16 @@
 module GovukMessageQueueConsumer
   class JSONProcessor
+    JSON_FORMAT = "application/json".freeze
+
     def initialize(next_processor)
       @next_processor = next_processor
     end
 
     def process(message)
-      message.payload = JSON.parse(message.payload)
+      if message.headers.content_type == JSON_FORMAT
+        message.payload = JSON.parse(message.payload)
+      end
+
       @next_processor.process(message)
     rescue JSON::ParserError => e
       Airbrake.notify_or_ignore(e) if defined?(Airbrake)

--- a/lib/govuk_message_queue_consumer/json_processor.rb
+++ b/lib/govuk_message_queue_consumer/json_processor.rb
@@ -7,7 +7,8 @@ module GovukMessageQueueConsumer
     def process(message)
       message.payload = JSON.parse(message.payload)
       @next_processor.process(message)
-    rescue JSON::ParserError
+    rescue JSON::ParserError => e
+      Airbrake.notify_or_ignore(e) if defined?(Airbrake)
       message.discard
     end
   end

--- a/lib/govuk_message_queue_consumer/json_processor.rb
+++ b/lib/govuk_message_queue_consumer/json_processor.rb
@@ -1,0 +1,14 @@
+module GovukMessageQueueConsumer
+  class JSONProcessor
+    def initialize(next_processor)
+      @next_processor = next_processor
+    end
+
+    def process(message)
+      message.payload = JSON.parse(message.payload)
+      @next_processor.process(message)
+    rescue JSON::ParserError
+      message.discard
+    end
+  end
+end

--- a/lib/govuk_message_queue_consumer/message.rb
+++ b/lib/govuk_message_queue_consumer/message.rb
@@ -3,16 +3,12 @@ require 'json'
 module GovukMessageQueueConsumer
   # Client code will receive an instance of this
   class Message
+    attr_reader :delivery_info, :headers, :payload
+
     def initialize(delivery_info, headers, payload)
       @delivery_info = delivery_info
       @headers = headers
-      @body = payload
-    end
-
-    attr_reader :delivery_info, :headers, :body
-
-    def body_data
-      @body_data ||= JSON.parse(@body)
+      @payload = payload
     end
 
     def ack

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -1,14 +1,14 @@
 module GovukMessageQueueConsumer
   class MockMessage
-    attr_reader :acked, :retried, :discarded, :body_data, :delivery_info,
-                :headers, :body
+    attr_reader :acked, :retried, :discarded
+    attr_accessor :payload, :delivery_info, :headers
 
     alias :acked? :acked
     alias :discarded? :discarded
     alias :retried? :retried
 
-    def initialize(body_data = {})
-      @body_data = body_data
+    def initialize(payload = {})
+      @payload = payload
     end
 
     def ack

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -7,8 +7,9 @@ module GovukMessageQueueConsumer
     alias :discarded? :discarded
     alias :retried? :retried
 
-    def initialize(payload = {})
+    def initialize(payload = {}, options = {})
       @payload = payload
+      @headers = OpenStruct.new(options[:headers])
     end
 
     def ack

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,27 +1,15 @@
 require_relative 'spec_helper'
 
 describe Consumer do
-  let(:message_values) { [:delivery_info1, :headers1, "message1_body"] }
+  let(:message_values) { [:delivery_info1, :headers1, "message1_payload"] }
   let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: message_values) }
   let(:channel) { instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil) }
   let(:rabbitmq_connecton) { instance_double("Bunny::Session", start: nil, create_channel: channel) }
   let(:client_processor) { instance_double('Client::Processor') }
 
   before do
+    stub_environment_variables!
     allow(Bunny).to receive(:new).and_return(rabbitmq_connecton)
-  end
-
-  describe "constructing an instance" do
-    let(:rabbitmq_connecton) { instance_double("Bunny::Session", start: nil, create_channel: channel) }
-    let(:client_processor) { instance_double('Client::Processor') }
-
-    it "passes the client processor to the Heartbeat Processor" do
-      stub_environment_variables!
-
-      expect(HeartbeatProcessor).to receive(:new).with(client_processor)
-
-      Consumer.new(queue_name: "some-queue", exchange: "my-exchange", processor: client_processor)
-    end
   end
 
   describe "running the consumer" do

--- a/spec/json_processor_spec.rb
+++ b/spec/json_processor_spec.rb
@@ -1,0 +1,23 @@
+require_relative 'spec_helper'
+
+describe JSONProcessor do
+  describe "#process" do
+    it "parses the payload string" do
+      next_processor = double("next_processor", process: "ha")
+      message = MockMessage.new('{"some":"json"}')
+
+      JSONProcessor.new(next_processor).process(message)
+
+      expect(message.payload).to eql({ "some" => "json" })
+      expect(next_processor).to have_received(:process)
+    end
+
+    it "discards messages with JSON errors" do
+      message = MockMessage.new('{"some" "json"}')
+
+      JSONProcessor.new(double).process(message)
+
+      expect(message).to be_discarded
+    end
+  end
+end

--- a/spec/json_processor_spec.rb
+++ b/spec/json_processor_spec.rb
@@ -4,7 +4,7 @@ describe JSONProcessor do
   describe "#process" do
     it "parses the payload string" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new('{"some":"json"}')
+      message = MockMessage.new('{"some":"json"}', headers: { content_type: "application/json" })
 
       JSONProcessor.new(next_processor).process(message)
 
@@ -13,11 +13,21 @@ describe JSONProcessor do
     end
 
     it "discards messages with JSON errors" do
-      message = MockMessage.new('{"some" "json"}')
+      message = MockMessage.new('{"some" "json"}', headers: { content_type: "application/json" })
 
       JSONProcessor.new(double).process(message)
 
       expect(message).to be_discarded
+    end
+
+    it "doesn't parse non-JSON message" do
+      next_processor = double("next_processor", process: "ha")
+      message = MockMessage.new('<SomeXML></SomeXML>', headers: { content_type: "application/xml" })
+
+      JSONProcessor.new(next_processor).process(message)
+
+      expect(message.payload).to eql('<SomeXML></SomeXML>')
+      expect(next_processor).to have_received(:process)
     end
   end
 end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -4,25 +4,23 @@ describe Message do
   let(:mock_channel) { instance_double("Channel") }
   let(:delivery_info) { instance_double("DeliveryInfo", :channel => mock_channel, :delivery_tag => "a_tag") }
   let(:headers) { instance_double("Headers") }
-  let(:body) { {"foo" => "bar"}.to_json }
-  let(:message) { Message.new(delivery_info, headers, body) }
-
-  it "json decodes the body" do
-    expect(message.body_data).to eq("foo" => "bar")
-  end
+  let(:message) { Message.new(delivery_info, headers, { "a" => "payload" }) }
 
   it "ack sends an ack to the channel" do
     expect(mock_channel).to receive(:ack).with("a_tag")
+
     message.ack
   end
 
   it "retry sends a reject to the channel with requeue set" do
     expect(mock_channel).to receive(:reject).with("a_tag", true)
+
     message.retry
   end
 
   it "reject sends a reject to the channel without requeue set" do
     expect(mock_channel).to receive(:reject).with("a_tag", false)
+
     message.discard
   end
 end


### PR DESCRIPTION
`email-alert-service`, one of the apps that will use this gem, has special behaviour for when the message received from RMQ isn't valid JSON. This may be a good thing to pull up into the gem.

We implement the check by refactoring the JSON parsing into a middleware processor, like `HeartbeatProcessor`. The responsibility of the `JSONProcessor` is to parse the `payload` attribute on `Message`.

I've considered an alternative, to keep the JSON parsing inside `Message`, but that would've meant that `Message` would discard itself whenever it encounters a parse error. Keeping this within a class seemed cleaner.

`Message` has been refactored to have use `payload` consistently. This is also the term RabbitMQ uses.