### PR TITLE
Add TestConsumer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ namespace :message_queue do
   task consumer: :environment do
     GovukMessageQueueConsumer::Consumer.new(
       queue_name: "some-queue",
-      exchange: "some-exchange",
+      exchange_name: "some-exchange",
       processor: MyProcessor.new
     ).run
   end

--- a/lib/govuk_message_queue_consumer/test_helpers.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers.rb
@@ -1,2 +1,3 @@
 require 'govuk_message_queue_consumer/test_helpers/shared_examples'
 require 'govuk_message_queue_consumer/test_helpers/mock_message'
+require 'govuk_message_queue_consumer/test_helpers/test_consumer'

--- a/lib/govuk_message_queue_consumer/test_helpers/test_consumer.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/test_consumer.rb
@@ -1,0 +1,7 @@
+module GovukMessageQueueConsumer
+  class TestConsumer < Consumer
+    def publish_message(payload, options)
+      exchange.publish(payload, options)
+    end
+  end
+end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -16,13 +16,13 @@ describe Consumer do
     it "binds the queue to the all-routing key" do
       expect(queue).to receive(:bind).with(nil, { routing_key: "#" })
 
-      Consumer.new(queue_name: "some-queue", exchange: "my-exchange", processor: client_processor).run
+      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run
     end
 
     it "binds the queue to a custom routing key" do
       expect(queue).to receive(:bind).with(nil, { routing_key: "*.major" })
 
-      Consumer.new(queue_name: "some-queue", exchange: "my-exchange", processor: client_processor, routing_key: "*.major").run
+      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor, routing_key: "*.major").run
     end
 
     it "calls the heartbeat processor when subscribing to messages" do
@@ -30,7 +30,7 @@ describe Consumer do
       expect(Message).to receive(:new).with(*message_values)
       expect_any_instance_of(HeartbeatProcessor).to receive(:process)
 
-      Consumer.new(queue_name: "some-queue", exchange: "my-exchange", processor: client_processor).run
+      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run
     end
   end
 end


### PR DESCRIPTION
This message can be used by the consumers in an integration test. We add this method here to avoid exposing `exchange` publicly.

The first commit refactors `Consumer` to make this change easier.