### PR TITLE
Make MockMessage inherit from Message

### DIFF
--- a/lib/govuk_message_queue_consumer/message.rb
+++ b/lib/govuk_message_queue_consumer/message.rb
@@ -3,7 +3,7 @@ require 'json'
 module GovukMessageQueueConsumer
   # Client code will receive an instance of this
   class Message
-    attr_reader :delivery_info, :headers, :payload
+    attr_accessor :delivery_info, :headers, :payload
 
     def initialize(delivery_info, headers, payload)
       @delivery_info = delivery_info

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -1,7 +1,6 @@
 module GovukMessageQueueConsumer
-  class MockMessage
+  class MockMessage < Message
     attr_reader :acked, :retried, :discarded
-    attr_accessor :payload, :delivery_info, :headers
 
     alias :acked? :acked
     alias :discarded? :discarded


### PR DESCRIPTION
This makes it easier to implement new methods and ensure they have the same interface.