### PR TITLE
Routing key per message processor

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ notified of changes in content.
 - **Queue**: a queue listens to an exchange. In most cases the queue will listen
   to all messages, but it's also possible to listen to a specific pattern.
 - **Processor**: the specific class that processes a message.
+- **Routing key**: Restricts the messages that can get pushed onto a queue by the exchange.
 
 ## Technical documentation
 

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -20,7 +20,7 @@ module GovukMessageQueueConsumer
     def run
       queue.subscribe(block: true, manual_ack: true) do |delivery_info, headers, payload|
         begin
-          message = Message.new(delivery_info, headers, payload)
+          message = Message.new(payload, headers, delivery_info)
           processor_chain.process(message)
         rescue Exception => e
           $stderr.puts "rabbitmq_consumer: aborting due to unhandled exception in processor #{e.class}: #{e.message}"

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -18,7 +18,6 @@ module GovukMessageQueueConsumer
     end
 
     def run
-      puts "routing_key: #{routing_key}"
       queue.subscribe(block: true, manual_ack: true) do |delivery_info, headers, payload|
         begin
           message = Message.new(delivery_info, headers, payload)
@@ -62,7 +61,7 @@ module GovukMessageQueueConsumer
     end
 
     def routing_key
-      @processor.respond_to?(:routing_key) ? @processor.routing_key : "#"
+      @processor.routing_key
     end
   end
 end

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -61,7 +61,7 @@ module GovukMessageQueueConsumer
     end
 
     def routing_key
-      @processor.routing_key
+      @processor.class::ROUTING_KEY
     end
   end
 end

--- a/lib/govuk_message_queue_consumer/message.rb
+++ b/lib/govuk_message_queue_consumer/message.rb
@@ -5,10 +5,10 @@ module GovukMessageQueueConsumer
   class Message
     attr_accessor :delivery_info, :headers, :payload
 
-    def initialize(delivery_info, headers, payload)
-      @delivery_info = delivery_info
+    def initialize(payload, headers, delivery_info)
       @headers = headers
       @payload = payload
+      @delivery_info = delivery_info
     end
 
     def ack

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -6,10 +6,10 @@ module GovukMessageQueueConsumer
     alias :discarded? :discarded
     alias :retried? :retried
 
-    def initialize(delivery_info = {}, payload = {}, options = {})
-      @delivery_info = OpenStruct.new(delivery_info)
+    def initialize(payload = {}, options = {}, delivery_info = {})
       @payload = payload
       @headers = OpenStruct.new(options[:headers])
+      @delivery_info = OpenStruct.new(delivery_info)
     end
 
     def ack

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -6,7 +6,8 @@ module GovukMessageQueueConsumer
     alias :discarded? :discarded
     alias :retried? :retried
 
-    def initialize(payload = {}, options = {})
+    def initialize(delivery_info = {}, payload = {}, options = {})
+      @delivery_info = OpenStruct.new(delivery_info)
       @payload = payload
       @headers = OpenStruct.new(options[:headers])
     end

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -6,9 +6,9 @@ module GovukMessageQueueConsumer
     alias :discarded? :discarded
     alias :retried? :retried
 
-    def initialize(payload = {}, options = {}, delivery_info = {})
+    def initialize(payload = {}, headers = {}, delivery_info = {})
       @payload = payload
-      @headers = OpenStruct.new(options[:headers])
+      @headers = OpenStruct.new(headers)
       @delivery_info = OpenStruct.new(delivery_info)
     end
 

--- a/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
@@ -8,13 +8,13 @@ if defined?(RSpec)
       expect(subject.method(:process).arity).to eq(1)
     end
 
-    it "implements #routing_key" do
-      expect(subject).to respond_to(:routing_key)
+    it "sets a ROUTING_KEY" do
+      expect { subject.class.const_get("ROUTING_KEY") }.not_to raise_error
     end
 
-    it "returns a useful routing_key" do
-      expect(subject.routing_key).not_to eq("")
-      expect(subject.routing_key).not_to be_nil
+    it "returns a useful ROUTING_KEY" do
+      expect(subject.class::ROUTING_KEY).not_to eq("")
+      expect(subject.class::ROUTING_KEY).not_to be_nil
     end
   end
 end

--- a/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/shared_examples.rb
@@ -7,5 +7,14 @@ if defined?(RSpec)
     it "accepts 1 argument for #process" do
       expect(subject.method(:process).arity).to eq(1)
     end
+
+    it "implements #routing_key" do
+      expect(subject).to respond_to(:routing_key)
+    end
+
+    it "returns a useful routing_key" do
+      expect(subject.routing_key).not_to eq("")
+      expect(subject.routing_key).not_to be_nil
+    end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,7 +1,8 @@
 require_relative 'spec_helper'
 
 describe Consumer do
-  let(:message_values) { [:delivery_info1, :headers1, "message1_payload"] }
+  let(:yield_values) { [:delivery_info1, :headers1, "message1_payload"] }
+  let(:message_values) { ["message1_payload", :headers1, :delivery_info1] }
   let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: message_values) }
   let(:channel) { instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil) }
   let(:rabbitmq_connecton) { instance_double("Bunny::Session", start: nil, create_channel: channel) }
@@ -26,7 +27,7 @@ describe Consumer do
     end
 
     it "calls the heartbeat processor when subscribing to messages" do
-      expect(queue).to receive(:subscribe).and_yield(*message_values)
+      expect(queue).to receive(:subscribe).and_yield(*yield_values)
       expect(Message).to receive(:new).with(*message_values)
       expect_any_instance_of(HeartbeatProcessor).to receive(:process)
 

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,12 +1,9 @@
 require_relative 'spec_helper'
 
 describe Consumer do
-  let(:yield_values) { [:delivery_info1, :headers1, "message1_payload"] }
-  let(:message_values) { ["message1_payload", :headers1, :delivery_info1] }
-  let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: message_values) }
+  let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: nil) }
   let(:channel) { instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil) }
   let(:rabbitmq_connecton) { instance_double("Bunny::Session", start: nil, create_channel: channel) }
-  let(:client_processor) { instance_double('Client::Processor', routing_key: nil) }
 
   before do
     stub_environment_variables!
@@ -14,24 +11,23 @@ describe Consumer do
   end
 
   describe "running the consumer" do
-    it "binds the queue to a custom routing key" do
-      class Processor
-        def routing_key
-          "*.major"
-        end
-      end
 
+    class Processor
+      ROUTING_KEY = "*.major"
+    end
+
+    it "binds the queue to a custom routing key" do
       expect(queue).to receive(:bind).with(nil, { routing_key: "*.major" })
 
       Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: Processor.new).run
     end
 
     it "calls the heartbeat processor when subscribing to messages" do
-      expect(queue).to receive(:subscribe).and_yield(*yield_values)
-      expect(Message).to receive(:new).with(*message_values)
+      expect(queue).to receive(:subscribe).and_yield(:delivery_info1, :headers1, "message1_payload")
+      expect(Message).to receive(:new).with("message1_payload", :headers1, :delivery_info1)
       expect_any_instance_of(HeartbeatProcessor).to receive(:process)
 
-      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run
+      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: Processor.new).run
     end
   end
 end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -13,18 +13,6 @@ describe Consumer do
   end
 
   describe "running the consumer" do
-    it "binds the queue to the all-routing key" do
-      class Processor
-        def routing_key
-          "#"
-        end
-      end
-
-      expect(queue).to receive(:bind).with(nil, { routing_key: "#" })
-
-      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: Processor.new).run
-    end
-
     it "binds the queue to a custom routing key" do
       class Processor
         def routing_key

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -14,15 +14,24 @@ describe Consumer do
 
   describe "running the consumer" do
     it "binds the queue to the all-routing key" do
+      class Processor
+      end
+
       expect(queue).to receive(:bind).with(nil, { routing_key: "#" })
 
-      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run
+      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: Processor.new).run
     end
 
     it "binds the queue to a custom routing key" do
+      class Processor
+        def routing_key
+          "*.major"
+        end
+      end
+
       expect(queue).to receive(:bind).with(nil, { routing_key: "*.major" })
 
-      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor, routing_key: "*.major").run
+      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: Processor.new).run
     end
 
     it "calls the heartbeat processor when subscribing to messages" do

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -5,7 +5,7 @@ describe Consumer do
   let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: message_values) }
   let(:channel) { instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil) }
   let(:rabbitmq_connecton) { instance_double("Bunny::Session", start: nil, create_channel: channel) }
-  let(:client_processor) { instance_double('Client::Processor') }
+  let(:client_processor) { instance_double('Client::Processor', routing_key: nil) }
 
   before do
     stub_environment_variables!
@@ -15,6 +15,9 @@ describe Consumer do
   describe "running the consumer" do
     it "binds the queue to the all-routing key" do
       class Processor
+        def routing_key
+          "#"
+        end
       end
 
       expect(queue).to receive(:bind).with(nil, { routing_key: "#" })

--- a/spec/json_processor_spec.rb
+++ b/spec/json_processor_spec.rb
@@ -4,7 +4,7 @@ describe JSONProcessor do
   describe "#process" do
     it "parses the payload string" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new({delivery:'info'}, '{"some":"json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new('{"some":"json"}', headers: { content_type: "application/json" })
 
       JSONProcessor.new(next_processor).process(message)
 
@@ -13,7 +13,7 @@ describe JSONProcessor do
     end
 
     it "discards messages with JSON errors" do
-      message = MockMessage.new({delivery:'info'}, '{"some" "json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new('{"some" "json"}', headers: { content_type: "application/json" })
 
       JSONProcessor.new(double).process(message)
 
@@ -22,7 +22,7 @@ describe JSONProcessor do
 
     it "doesn't parse non-JSON message" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new({delivery:'info'}, '<SomeXML></SomeXML>', headers: { content_type: "application/xml" })
+      message = MockMessage.new('<SomeXML></SomeXML>', headers: { content_type: "application/xml" })
 
       JSONProcessor.new(next_processor).process(message)
 

--- a/spec/json_processor_spec.rb
+++ b/spec/json_processor_spec.rb
@@ -2,9 +2,10 @@ require_relative 'spec_helper'
 
 describe JSONProcessor do
   describe "#process" do
+
     it "parses the payload string" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new('{"some":"json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new('{"some":"json"}', { content_type: "application/json" })
 
       JSONProcessor.new(next_processor).process(message)
 
@@ -13,7 +14,7 @@ describe JSONProcessor do
     end
 
     it "discards messages with JSON errors" do
-      message = MockMessage.new('{"some" "json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new('{"some" "json"}', { content_type: "application/json" })
 
       JSONProcessor.new(double).process(message)
 
@@ -22,7 +23,7 @@ describe JSONProcessor do
 
     it "doesn't parse non-JSON message" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new('<SomeXML></SomeXML>', headers: { content_type: "application/xml" })
+      message = MockMessage.new('<SomeXML></SomeXML>', { content_type: "application/xml" })
 
       JSONProcessor.new(next_processor).process(message)
 

--- a/spec/json_processor_spec.rb
+++ b/spec/json_processor_spec.rb
@@ -4,7 +4,7 @@ describe JSONProcessor do
   describe "#process" do
     it "parses the payload string" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new('{"some":"json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new({delivery:'info'}, '{"some":"json"}', headers: { content_type: "application/json" })
 
       JSONProcessor.new(next_processor).process(message)
 
@@ -13,7 +13,7 @@ describe JSONProcessor do
     end
 
     it "discards messages with JSON errors" do
-      message = MockMessage.new('{"some" "json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new({delivery:'info'}, '{"some" "json"}', headers: { content_type: "application/json" })
 
       JSONProcessor.new(double).process(message)
 
@@ -22,7 +22,7 @@ describe JSONProcessor do
 
     it "doesn't parse non-JSON message" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new('<SomeXML></SomeXML>', headers: { content_type: "application/xml" })
+      message = MockMessage.new({delivery:'info'}, '<SomeXML></SomeXML>', headers: { content_type: "application/xml" })
 
       JSONProcessor.new(next_processor).process(message)
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -3,8 +3,7 @@ require_relative 'spec_helper'
 describe Message do
   let(:mock_channel) { instance_double("Channel") }
   let(:delivery_info) { instance_double("DeliveryInfo", :channel => mock_channel, :delivery_tag => "a_tag") }
-  let(:headers) { instance_double("Headers") }
-  let(:message) { Message.new({ "a" => "payload" }, headers, delivery_info) }
+  let(:message) { Message.new({ "a" => "payload" }, double, delivery_info) }
 
   it "ack sends an ack to the channel" do
     expect(mock_channel).to receive(:ack).with("a_tag")

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -4,7 +4,7 @@ describe Message do
   let(:mock_channel) { instance_double("Channel") }
   let(:delivery_info) { instance_double("DeliveryInfo", :channel => mock_channel, :delivery_tag => "a_tag") }
   let(:headers) { instance_double("Headers") }
-  let(:message) { Message.new(delivery_info, headers, { "a" => "payload" }) }
+  let(:message) { Message.new({ "a" => "payload" }, headers, delivery_info) }
 
   it "ack sends an ack to the channel" do
     expect(mock_channel).to receive(:ack).with("a_tag")

--- a/spec/mock_message_spec.rb
+++ b/spec/mock_message_spec.rb
@@ -4,7 +4,7 @@ require_relative '../lib/govuk_message_queue_consumer/test_helpers/mock_message'
 describe GovukMessageQueueConsumer::MockMessage do
   describe '#methods' do
     it "implements the same methods as Message" do
-      mock = MockMessage.new(double)
+      mock = MockMessage.new
       real = Message.new(double, double, double)
 
       expect(real.methods - mock.methods).to be_empty


### PR DESCRIPTION
Message processors should provide their own routing details.

This makes the Consumer code a bit cleaner and allows us to enforce a specification for the routing key via the shared examples.

Part of: https://trello.com/c/z8b6VmCU/317-update-panopticon-when-links-are-sent-to-publishing-api