### PR TITLE
Improve testing

### DIFF
--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -6,9 +6,10 @@ module GovukMessageQueueConsumer
     alias :discarded? :discarded
     alias :retried? :retried
 
-    def initialize(payload = {}, options = {})
+    def initialize(delivery_info = {}, headers = {}, payload = {})
+      @delivery_info = OpenStruct.new(delivery_info)
+      @headers = OpenStruct.new(headers)
       @payload = payload
-      @headers = OpenStruct.new(options[:headers])
     end
 
     def ack

--- a/lib/govuk_message_queue_consumer/test_helpers/test_consumer.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/test_consumer.rb
@@ -3,5 +3,10 @@ module GovukMessageQueueConsumer
     def publish_message(payload, options)
       exchange.publish(payload, options)
     end
+
+    # call after integration tests finish
+    def delete_queue
+      queue.delete
+    end
   end
 end

--- a/spec/json_processor_spec.rb
+++ b/spec/json_processor_spec.rb
@@ -4,7 +4,7 @@ describe JSONProcessor do
   describe "#process" do
     it "parses the payload string" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new('{"some":"json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new({}, { content_type: "application/json" }, '{"some":"json"}')
 
       JSONProcessor.new(next_processor).process(message)
 
@@ -13,7 +13,7 @@ describe JSONProcessor do
     end
 
     it "discards messages with JSON errors" do
-      message = MockMessage.new('{"some" "json"}', headers: { content_type: "application/json" })
+      message = MockMessage.new({}, { content_type: "application/json" }, '{"some" "json"}')
 
       JSONProcessor.new(double).process(message)
 
@@ -22,7 +22,7 @@ describe JSONProcessor do
 
     it "doesn't parse non-JSON message" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new('<SomeXML></SomeXML>', headers: { content_type: "application/xml" })
+      message = MockMessage.new({}, { content_type: "application/xml" }, '<SomeXML></SomeXML>')
 
       JSONProcessor.new(next_processor).process(message)
 

--- a/spec/mock_message_spec.rb
+++ b/spec/mock_message_spec.rb
@@ -4,7 +4,7 @@ require_relative '../lib/govuk_message_queue_consumer/test_helpers/mock_message'
 describe GovukMessageQueueConsumer::MockMessage do
   describe '#methods' do
     it "implements the same methods as Message" do
-      mock = MockMessage.new(double)
+      mock = MockMessage.new
       real = Message.new(double, double, double)
 
       expect(real.methods - mock.methods).to be_empty


### PR DESCRIPTION
Old queues and routing keys hanging around after the tests finish can cause confusion.

Purge the queue of messages and unbind the queue from the exchange

This PR needs to be merged and then the gem version bumped, etc, before these dependent PRs can be merged:
https://github.com/alphagov/email-alert-service/pull/42
https://github.com/alphagov/content-register/pull/28