### PR TITLE
Flip the parameters to `Message`

### DIFF
--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -21,7 +21,7 @@ module GovukMessageQueueConsumer
     def run
       queue.subscribe(block: true, manual_ack: true) do |delivery_info, headers, payload|
         begin
-          message = Message.new(delivery_info, headers, payload)
+          message = Message.new(payload, headers, delivery_info)
           processor_chain.process(message)
         rescue Exception => e
           $stderr.puts "rabbitmq_consumer: aborting due to unhandled exception in processor #{e.class}: #{e.message}"

--- a/lib/govuk_message_queue_consumer/message.rb
+++ b/lib/govuk_message_queue_consumer/message.rb
@@ -5,10 +5,10 @@ module GovukMessageQueueConsumer
   class Message
     attr_accessor :delivery_info, :headers, :payload
 
-    def initialize(delivery_info, headers, payload)
-      @delivery_info = delivery_info
-      @headers = headers
+    def initialize(payload, headers, delivery_info)
       @payload = payload
+      @headers = headers
+      @delivery_info = delivery_info
     end
 
     def ack

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -6,10 +6,10 @@ module GovukMessageQueueConsumer
     alias :discarded? :discarded
     alias :retried? :retried
 
-    def initialize(delivery_info = {}, headers = {}, payload = {})
-      @delivery_info = OpenStruct.new(delivery_info)
-      @headers = OpenStruct.new(headers)
+    def initialize(payload = {}, headers = {}, delivery_info = {})
       @payload = payload
+      @headers = OpenStruct.new(headers)
+      @delivery_info = OpenStruct.new(delivery_info)
     end
 
     def ack

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,8 +1,7 @@
 require_relative 'spec_helper'
 
 describe Consumer do
-  let(:message_values) { [:delivery_info1, :headers1, "message1_payload"] }
-  let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: message_values) }
+  let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: '') }
   let(:channel) { instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil) }
   let(:rabbitmq_connecton) { instance_double("Bunny::Session", start: nil, create_channel: channel) }
   let(:client_processor) { instance_double('Client::Processor') }
@@ -26,8 +25,8 @@ describe Consumer do
     end
 
     it "calls the heartbeat processor when subscribing to messages" do
-      expect(queue).to receive(:subscribe).and_yield(*message_values)
-      expect(Message).to receive(:new).with(*message_values)
+      expect(queue).to receive(:subscribe).and_yield(:delivery_info_object, :headers, "payload")
+      expect(Message).to receive(:new).with("payload", :headers, :delivery_info_object)
       expect_any_instance_of(HeartbeatProcessor).to receive(:process)
 
       Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run

--- a/spec/json_processor_spec.rb
+++ b/spec/json_processor_spec.rb
@@ -4,7 +4,7 @@ describe JSONProcessor do
   describe "#process" do
     it "parses the payload string" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new({}, { content_type: "application/json" }, '{"some":"json"}')
+      message = MockMessage.new('{"some":"json"}', { content_type: "application/json" })
 
       JSONProcessor.new(next_processor).process(message)
 
@@ -13,7 +13,7 @@ describe JSONProcessor do
     end
 
     it "discards messages with JSON errors" do
-      message = MockMessage.new({}, { content_type: "application/json" }, '{"some" "json"}')
+      message = MockMessage.new('{"some" "json"}', { content_type: "application/json" })
 
       JSONProcessor.new(double).process(message)
 
@@ -22,7 +22,7 @@ describe JSONProcessor do
 
     it "doesn't parse non-JSON message" do
       next_processor = double("next_processor", process: "ha")
-      message = MockMessage.new({}, { content_type: "application/xml" }, '<SomeXML></SomeXML>')
+      message = MockMessage.new('<SomeXML></SomeXML>', { content_type: "application/xml" })
 
       JSONProcessor.new(next_processor).process(message)
 

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -4,7 +4,7 @@ describe Message do
   let(:mock_channel) { instance_double("Channel") }
   let(:delivery_info) { instance_double("DeliveryInfo", :channel => mock_channel, :delivery_tag => "a_tag") }
   let(:headers) { instance_double("Headers") }
-  let(:message) { Message.new(delivery_info, headers, { "a" => "payload" }) }
+  let(:message) { Message.new({ "a" => "payload" }, headers, delivery_info) }
 
   it "ack sends an ack to the channel" do
     expect(mock_channel).to receive(:ack).with("a_tag")


### PR DESCRIPTION
By reordering the parameters from most-used to least-used, we can
declutter the tests in consuming apps in the most common scenario:

```
MockMessage.new({}, {}, payload)
```

vs

```
MockMessage.new(payload)
```

This was originally done in https://github.com/alphagov/govuk_message_queue_consumer/pull/24.