### PR TITLE
Add statsd support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ tmp
 .DS_Store
 *~
 Gemfile.lock
+doc
+.yardoc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add support for sending stats to Statsd
+
 # 2.0.1
 
 * Add support for Airbrake.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ the content-items it receives, so that applications such as
 [email-alert-service](https://github.com/alphagov/email-alert-service) can be
 notified of changes in content.
 
+For detailed documentation, check out the [gem documentation on rubydoc.info](http://www.rubydoc.info/gems/govuk_message_queue_consumer/GovukMessageQueueConsumer/Consumer#initialize-instance_method).
+
 ## Nomenclature
 
 ![A graph showing the message flow](docs/graph.png)
@@ -69,6 +71,8 @@ namespace :message_queue do
   end
 end
 ```
+
+More options are [documented here](http://www.rubydoc.info/gems/govuk_message_queue_consumer/GovukMessageQueueConsumer/Consumer#initialize-instance_method).
 
 The consumer expects a number of environment variables to be present. On GOV.UK,
 these should be set up in puppet.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,28 @@ class MyProcessor
 end
 ```
 
+### Statsd integration
+
+You can pass a `statsd_client` to the `GovukMessageQueueConsumer::Consumer` initializer. The consumer will emit counters to statsd with these keys:
+
+- `your_queue_name.started` - message picked up from the your_queue_name
+- `your_queue_name.retried` - message has been retried
+- `your_queue_name.acked` - message has been processed and acked
+- `your_queue_name.discarded` - message has been discarded
+- `your_queue_name.uncaught_exception` - an uncaught exception occured during processing
+
+Remember to use a namespace for the `Statsd` client:
+
+```ruby
+statsd_client = Statsd.new("localhost")
+statsd_client.namespace = "govuk.app.my_app_name"
+
+GovukMessageQueueConsumer::Consumer.new(
+  statsd_client: statsd_client
+  # ... other setup code omitted
+).run
+```
+
 ### Testing your processor
 
 This gem provides a test helper for your processor.

--- a/govuk_message_queue_consumer.gemspec
+++ b/govuk_message_queue_consumer.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'gem_publisher', '~> 1.5.0'
   s.add_development_dependency 'rspec', '~> 3.3.0'
   s.add_development_dependency 'rake', '~> 10.4.2'
+  s.add_development_dependency 'yard'
 end

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -31,7 +31,7 @@ module GovukMessageQueueConsumer
           processor_chain.process(message)
         rescue Exception => e
           Airbrake.notify_or_ignore(e) if defined?(Airbrake)
-          $stderr.puts "Uncaught exception in processor: \n\n #{e.class}: #{e.message}\n\n#{e.backtrace}"
+          $stderr.puts "Uncaught exception in processor: \n\n #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}"
           exit(1) # Ensure rabbitmq requeues outstanding messages
         end
       end

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -11,6 +11,12 @@ module GovukMessageQueueConsumer
     # time to share the work evenly.
     NUMBER_OF_MESSAGES_TO_PREFETCH = 1
 
+    # Create a new consumer
+    #
+    # @param queue_name [String] Your queue name. This is specific to your application.
+    # @param exchange_name [String] Name of the exchange to bind to, for example `published_documents`
+    # @param processor [Object] An object that responds to `process`
+    # @param routing_key [String] The RabbitMQ routing key to bind the queue to
     def initialize(queue_name:, exchange_name:, processor:, routing_key: '#')
       @queue_name = queue_name
       @exchange_name = exchange_name

--- a/lib/govuk_message_queue_consumer/message.rb
+++ b/lib/govuk_message_queue_consumer/message.rb
@@ -3,24 +3,28 @@ require 'json'
 module GovukMessageQueueConsumer
   # Client code will receive an instance of this
   class Message
-    attr_accessor :delivery_info, :headers, :payload
+    attr_accessor :delivery_info, :headers, :payload, :status
 
     def initialize(payload, headers, delivery_info)
       @payload = payload
       @headers = headers
       @delivery_info = delivery_info
+      @status = :status
     end
 
     def ack
       @delivery_info.channel.ack(@delivery_info.delivery_tag)
+      @status = :acked
     end
 
     def retry
       @delivery_info.channel.reject(@delivery_info.delivery_tag, true)
+      @status = :retried
     end
 
     def discard
       @delivery_info.channel.reject(@delivery_info.delivery_tag, false)
+      @status = :discarded
     end
   end
 end

--- a/lib/govuk_message_queue_consumer/null_statsd.rb
+++ b/lib/govuk_message_queue_consumer/null_statsd.rb
@@ -1,0 +1,4 @@
+class NullStatsd
+  def increment(_key)
+  end
+end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -26,8 +26,7 @@ describe Consumer do
 
     it "calls the heartbeat processor when subscribing to messages" do
       expect(queue).to receive(:subscribe).and_yield(:delivery_info_object, :headers, "payload")
-      expect(Message).to receive(:new).with("payload", :headers, :delivery_info_object)
-      expect_any_instance_of(HeartbeatProcessor).to receive(:process)
+      expect_any_instance_of(HeartbeatProcessor).to receive(:process).with(kind_of(Message))
 
       Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run
     end

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -1,31 +1,33 @@
 require_relative 'spec_helper'
+require_relative 'support/queue_helpers'
 
 describe Consumer do
-  let(:queue) { instance_double('Bunny::Queue', bind: nil, subscribe: '') }
-  let(:channel) { instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil) }
-  let(:rabbitmq_connecton) { instance_double("Bunny::Session", start: nil, create_channel: channel) }
-  let(:client_processor) { instance_double('Client::Processor') }
+  include QueueHelpers
 
-  before do
-    stub_environment_variables!
-    allow(Bunny).to receive(:new).and_return(rabbitmq_connecton)
-  end
+  let(:client_processor) { instance_double('Client::Processor') }
 
   describe "#run" do
     it "binds the queue to the all-routing key" do
+      queue = create_stubbed_queue
+
       expect(queue).to receive(:bind).with(nil, { routing_key: "#" })
 
       Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run
     end
 
     it "binds the queue to a custom routing key" do
+      queue = create_stubbed_queue
+
       expect(queue).to receive(:bind).with(nil, { routing_key: "*.major" })
 
       Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor, routing_key: "*.major").run
     end
 
     it "calls the heartbeat processor when subscribing to messages" do
+      queue = create_stubbed_queue
+
       expect(queue).to receive(:subscribe).and_yield(:delivery_info_object, :headers, "payload")
+
       expect_any_instance_of(HeartbeatProcessor).to receive(:process).with(kind_of(Message))
 
       Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: client_processor).run

--- a/spec/consumer_spec.rb
+++ b/spec/consumer_spec.rb
@@ -11,7 +11,7 @@ describe Consumer do
     allow(Bunny).to receive(:new).and_return(rabbitmq_connecton)
   end
 
-  describe "running the consumer" do
+  describe "#run" do
     it "binds the queue to the all-routing key" do
       expect(queue).to receive(:bind).with(nil, { routing_key: "#" })
 

--- a/spec/consumer_with_statsd_spec.rb
+++ b/spec/consumer_with_statsd_spec.rb
@@ -1,0 +1,54 @@
+require_relative 'spec_helper'
+require_relative 'support/queue_helpers'
+
+describe Consumer do
+  include QueueHelpers
+
+  describe "#run" do
+    it "increments the counters on the statsd client" do
+      statsd_client = StatsdClientMock.new
+      queue = create_stubbed_queue
+
+      expect(queue).to receive(:subscribe).and_yield(
+        double(:delivery_info, channel: double(:channel, reject: double), delivery_tag: double),
+        double(:headers, content_type: 'application/json'),
+        "message_payload"
+      )
+
+      Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: double, statsd_client: statsd_client).run
+
+      expect(statsd_client.incremented_keys).to eql(['some-queue.started', 'some-queue.discarded'])
+    end
+
+    it "increments the uncaught_exception counter for uncaught exceptions" do
+      statsd_client = StatsdClientMock.new
+      queue = create_stubbed_queue
+
+      expect(queue).to receive(:subscribe).and_yield(
+        double(:delivery_info, channel: double(:channel, reject: double), delivery_tag: double),
+        double(:headers, content_type: 'application/json'),
+        {}.to_json
+      )
+
+      processor = double
+      expect(processor).to receive(:process).and_raise("An exception")
+
+      expect do
+        Consumer.new(queue_name: "some-queue", exchange_name: "my-exchange", processor: processor, statsd_client: statsd_client).run
+      end.to raise_error(SystemExit)
+
+      expect(statsd_client.incremented_keys).to eql(['some-queue.started', 'some-queue.uncaught_exception'])
+    end
+  end
+
+  class StatsdClientMock
+    attr_reader :incremented_keys
+    def initialize
+      @incremented_keys = []
+    end
+
+    def increment(key)
+      @incremented_keys << key
+    end
+  end
+end

--- a/spec/message_spec.rb
+++ b/spec/message_spec.rb
@@ -10,17 +10,23 @@ describe Message do
     expect(mock_channel).to receive(:ack).with("a_tag")
 
     message.ack
+
+    expect(message.status).to eql(:acked)
   end
 
   it "retry sends a reject to the channel with requeue set" do
     expect(mock_channel).to receive(:reject).with("a_tag", true)
 
     message.retry
+
+    expect(message.status).to eql(:retried)
   end
 
   it "reject sends a reject to the channel without requeue set" do
     expect(mock_channel).to receive(:reject).with("a_tag", false)
 
     message.discard
+
+    expect(message.status).to eql(:discarded)
   end
 end

--- a/spec/support/queue_helpers.rb
+++ b/spec/support/queue_helpers.rb
@@ -1,0 +1,10 @@
+module QueueHelpers
+  def create_stubbed_queue
+    stub_environment_variables!
+    queue = instance_double('Bunny::Queue', bind: nil, subscribe: '')
+    channel = instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil)
+    rabbitmq_connecton = instance_double("Bunny::Session", start: nil, create_channel: channel)
+    allow(Bunny).to receive(:new).and_return(rabbitmq_connecton)
+    queue
+  end
+end


### PR DESCRIPTION
This PR adds statsd support to this gem. When passed in a client, the consumer will start incrementing counters for the number of processed, failed, retried and errored messages. 

This will allow us to build a dashboard and add alerting for specific queues.

Trello: https://trello.com/c/Ipl9UVsA