### PR TITLE
Don't build test files in the gem

### DIFF
--- a/govuk_message_queue_consumer.gemspec
+++ b/govuk_message_queue_consumer.gemspec
@@ -13,8 +13,7 @@ Gem::Specification.new do |s|
   s.homepage = "https://github.com/alphagov/govuk_message_queue_consumer"
   s.email = ["govuk-dev@digital.cabinet-office.gov.uk"]
 
-  s.files = Dir.glob("lib/**/*") + %w{README.md Rakefile}
-  s.test_files = Dir["spec/*"]
+  s.files = Dir.glob("lib/**/*") + %w{LICENCE README.md CHANGELOG.md}
   s.require_path = 'lib'
 
   s.add_dependency 'bunny', '~> 2.2.0'


### PR DESCRIPTION
There is no need to include test files in a gem that will be used in production

Whilst it is true that not all gems are production ready, here at GOV.UK we shouldn't be shipping to production gems that contain test files.

Test files are completely useless in a production environment, besides providing them in a production environment can be very dangerous as it would be very easy to make a mistake.

For example we could be mocking the real Object that is used in production by accident.

Consider that we have mocked Bunny and accidentally we have executed the following in production, our RabbitMQ will never receive the data we were expecting.

```ruby
queue = instance_double('Bunny::Queue', bind: nil, subscribe: '')
channel = instance_double('Bunny::Channel', queue: queue, prefetch: nil, topic: nil)
rabbitmq_connecton = instance_double("Bunny::Session", start: nil, create_channel: channel)

allow(Bunny).to receive(:new).and_return(rabbitmq_connecton)
```

### Before

<img width="791" alt="screen shot 2016-04-20 at 10 57 37" src="https://cloud.githubusercontent.com/assets/136777/14670854/c797779a-06e6-11e6-9faa-10b4281ae952.png">

### After

<img width="897" alt="screen shot 2016-04-20 at 15 47 26" src="https://cloud.githubusercontent.com/assets/136777/14678911/8f2ec5b0-070f-11e6-9025-1aaaadea11f7.png">


[[read more](https://github.com/rubygems/rubygems/issues/735)]
