### PR TITLE
Remove test_consumer from test_helpers

### DIFF
--- a/lib/govuk_message_queue_consumer/test_helpers.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers.rb
@@ -1,3 +1,2 @@
 require 'govuk_message_queue_consumer/test_helpers/shared_examples'
 require 'govuk_message_queue_consumer/test_helpers/mock_message'
-require 'govuk_message_queue_consumer/test_helpers/test_consumer'


### PR DESCRIPTION
This was removed on PR [#34](https://github.com/alphagov/govuk_message_queue_consumer/pull/34/files#diff-00df42adf44cc945c8526a5a28c3dca1L1)

I have double checked that this is not breaking tests on Rummager and Panopticon (which use this gem)