### PR TITLE
Add more tests for test helpers

### DIFF
--- a/spec/mock_message_spec.rb
+++ b/spec/mock_message_spec.rb
@@ -1,5 +1,5 @@
 require_relative 'spec_helper'
-require_relative '../lib/govuk_message_queue_consumer/test_helpers/mock_message'
+require 'govuk_message_queue_consumer/test_helpers'
 
 describe GovukMessageQueueConsumer::MockMessage do
   describe '#methods' do

--- a/spec/test_helpers/mock_message_spec.rb
+++ b/spec/test_helpers/mock_message_spec.rb
@@ -1,4 +1,4 @@
-require_relative 'spec_helper'
+require_relative '../spec_helper'
 require 'govuk_message_queue_consumer/test_helpers'
 
 describe GovukMessageQueueConsumer::MockMessage do

--- a/spec/test_helpers/shared_examples_spec.rb
+++ b/spec/test_helpers/shared_examples_spec.rb
@@ -1,0 +1,13 @@
+require_relative '../spec_helper'
+require 'govuk_message_queue_consumer/test_helpers'
+
+describe "The usage of the shared example" do
+  class WellDevelopedMessageQueueConsumer
+    def process(_message)
+    end
+  end
+
+  describe WellDevelopedMessageQueueConsumer do
+    it_behaves_like "a message queue processor"
+  end
+end


### PR DESCRIPTION
This improves the testing of the test helpers, so that https://github.com/alphagov/govuk_message_queue_consumer/pull/36 can't happen again.