### PR TITLE
Update gem version to 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.1
+
+- Fix a bug that caused the test-helpers to error ([#34](https://github.com/alphagov/govuk_message_queue_consumer/pull/34))
+
 # 3.0.0
 
 - Updated README to conform changes on [PR #32](https://github.com/alphagov/govuk_message_queue_consumer/pull/32)

--- a/lib/govuk_message_queue_consumer/version.rb
+++ b/lib/govuk_message_queue_consumer/version.rb
@@ -1,3 +1,3 @@
 module GovukMessageQueueConsumer
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
This version solves the problem of requiring a previously deleted file,
we have taken action to prevent this from happening again by adding extra specs for our test_helper files.