### PR TITLE
Bump version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 3.0.2
+
+- Republish 3.0.1 to correct checksum.
+
 # 3.0.1
 
 - Fix a bug that caused the test-helpers to error ([#34](https://github.com/alphagov/govuk_message_queue_consumer/pull/34))

--- a/lib/govuk_message_queue_consumer/version.rb
+++ b/lib/govuk_message_queue_consumer/version.rb
@@ -1,3 +1,3 @@
 module GovukMessageQueueConsumer
-  VERSION = '3.0.1'
+  VERSION = '3.0.2'
 end


### PR DESCRIPTION
Since we switched to bundler 1.14, we've been unable to build rummager,
which depends on this gem.

This version validates checksums when installing gems: https://github.com/bundler/bundler/blob/5553e99a91a07bfd35925b88a5b3c9362f363841/CHANGELOG.md#1140pre1-2016-12-29

```
(More info: The expected SHA256 checksum was
"6779a7cd1495ca3df9ebf42f1081146ddcefe65dd8005c4ad07dd1e8ffd6ba09", but the
checksum for the downloaded gem was
"7b4743f1e5775098a36d4c3f0f6671cde50f9c9dea6c605a1e4f89299dcad33f".)
```

I've downloaded the gem manually and the checksum matched what bundler is
generating, so it seems like rubygems is wrong. I'm not seeing any difference
between the contents of the gem, and what we expect to be released.

Hopefully publishing a new version resolves the problem.