### PR TITLE
Use GovukError for error reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+- Change Airbrake to GovukError
+
 # 3.0.2
 
 - Republish 3.0.1 to correct checksum.

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -36,7 +36,7 @@ module GovukMessageQueueConsumer
           @statsd_client.increment("#{@queue_name}.#{message.status}")
         rescue Exception => e
           @statsd_client.increment("#{@queue_name}.uncaught_exception")
-          Airbrake.notify_or_ignore(e) if defined?(Airbrake)
+          GovukError.notify(e) if defined?(GovukError)
           @logger.error "Uncaught exception in processor: \n\n #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}"
           exit(1) # Ensure rabbitmq requeues outstanding messages
         end

--- a/lib/govuk_message_queue_consumer/json_processor.rb
+++ b/lib/govuk_message_queue_consumer/json_processor.rb
@@ -13,7 +13,7 @@ module GovukMessageQueueConsumer
 
       @next_processor.process(message)
     rescue JSON::ParserError => e
-      Airbrake.notify_or_ignore(e) if defined?(Airbrake)
+      GovukError.notify(e) if defined?(GovukError)
       message.discard
     end
   end


### PR DESCRIPTION
We've retired Airbrake and are now using Sentry via the govuk_app_config gem, which exposes the GovukError class.