### PR TITLE
Bump bunny from ~> 2.2.2 to ~> 2.11

### DIFF
--- a/govuk_message_queue_consumer.gemspec
+++ b/govuk_message_queue_consumer.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir.glob("lib/**/*") + %w{LICENCE README.md CHANGELOG.md}
   s.require_path = 'lib'
 
-  s.add_dependency 'bunny', '~> 2.2.0'
+  s.add_dependency 'bunny', '~> 2.11'
 
   s.add_development_dependency 'rspec', '~> 3.3.0'
   s.add_development_dependency 'rake', '~> 10.4.2'


### PR DESCRIPTION
The version specified is from December 2015. We're using bunny 2.11
in email-alert-service and publishing-api. rummager and
content-performance-manager will be affected by this
upgrade.

https://github.com/ruby-amqp/bunny/blob/master/ChangeLog.md