### PR TITLE
Add attribute readers to mock message class

### DIFF
--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -1,6 +1,6 @@
 module GovukMessageQueueConsumer
   class MockMessage < Message
-    attr_reader :acked, :retried, :discarded
+    attr_reader :acked, :retried, :discarded, :payload, :header, :delivery_info
 
     alias :acked? :acked
     alias :discarded? :discarded


### PR DESCRIPTION
This adds public access for payload, delivery_info and headers on mock message instances. This is helpful for tests using the mock message class and have expectations based on these attributes.