### PR TITLE
Fix intermittently failing batch consumer tests

### DIFF
--- a/spec/batch_consumer_spec.rb
+++ b/spec/batch_consumer_spec.rb
@@ -66,7 +66,7 @@ describe BatchConsumer do
       expect(processor).to receive(:process).with([instance_of(Message)]).twice
       with_consumer do
         @queue.publish(json: 'message')
-        sleep 0.2
+        sleep 0.4
         @queue.publish(json: 'message')
       end
     end


### PR DESCRIPTION
The tests examples for the BatchConsumer rely on the concurrency and timings between threads. Tests for the batch consumer's timeout could intermittently fail. This is due to processor thread potentially not being scheduled for long enough for the timeout to elapse before the subsequent messages are sent. This is not an absolute fix, but should lower the probability of the test failing.