### PR TITLE
Add subscribe options for Consumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Add ability to override default consumer subscribe options with `subscribe_opts` parameter
+
 # 3.3.0
 
 - Add access to `payload`, `delivery_info`, `header` in `GovukMessageQueueConsumer::MockMessage` for testing.

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -26,10 +26,11 @@ module GovukMessageQueueConsumer
       @logger = logger
     end
 
-    def run
+    def run(subscribe_opts: {})
       @rabbitmq_connection.start
 
-      queue.subscribe(block: true, manual_ack: true) do |delivery_info, headers, payload|
+      subscribe_opts = { block: true, manual_ack: true}.merge(subscribe_opts)
+      queue.subscribe(subscribe_opts) do |delivery_info, headers, payload|
         begin
           message = Message.new(payload, headers, delivery_info)
           @statsd_client.increment("#{@queue_name}.started")


### PR DESCRIPTION
This adds the ability to overwrite the default subscribe options for the Consumer. This is needed for setting up concurrent consumers as the `block` option needs to be set as false.