### PR TITLE
Stop reporting SignalExceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Stop reporting `SignalExceptions` to `GovukError`.
+
 # 3.4.0
 
 - Add ability to override default consumer subscribe options with `subscribe_opts` parameter

--- a/lib/govuk_message_queue_consumer/batch_consumer.rb
+++ b/lib/govuk_message_queue_consumer/batch_consumer.rb
@@ -49,6 +49,9 @@ module GovukMessageQueueConsumer
         end
         @statsd_client.increment("#{@queue_name}.batch_complete")
       end
+    rescue SignalException => e
+      @logger.error "SignalException in processor: \n\n #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}"
+      exit(1) # Ensure rabbitmq requeues outstanding messages
     rescue Exception => e
       @statsd_client.increment("#{@queue_name}.uncaught_exception")
       GovukError.notify(e) if defined?(GovukError)

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -36,6 +36,9 @@ module GovukMessageQueueConsumer
           @statsd_client.increment("#{@queue_name}.started")
           message_consumer.process(message)
           @statsd_client.increment("#{@queue_name}.#{message.status}")
+        rescue SignalException => e
+          @logger.error "SignalException in processor: \n\n #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}"
+          exit(1) # Ensure rabbitmq requeues outstanding messages
         rescue Exception => e
           @statsd_client.increment("#{@queue_name}.uncaught_exception")
           GovukError.notify(e) if defined?(GovukError)


### PR DESCRIPTION
These are normal, in the sense that Upstart will SIGTERM consumers
when they're being restarted, as part of a deployment for example.