### PR TITLE
Release major version 4.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# Unreleased
+# 4.0.0
 
-- Breaking: remove batch consumer
+- Breaking: remove batch consumer ([#73](https://github.com/alphagov/govuk_message_queue_consumer/pull/73))
 
 # 3.5.0
 

--- a/lib/govuk_message_queue_consumer/version.rb
+++ b/lib/govuk_message_queue_consumer/version.rb
@@ -1,3 +1,3 @@
 module GovukMessageQueueConsumer
-  VERSION = "3.5.0".freeze
+  VERSION = "4.0.0".freeze
 end


### PR DESCRIPTION
This major version removes the batch consumer, an experimental feature introduced in 2018 that was never used in production.

Do not merge yet, to be merged first:

* [TLC for this repo](https://github.com/alphagov/govuk_message_queue_consumer/pull/74) ✅
* [Switch to github actions](https://github.com/alphagov/govuk_message_queue_consumer/pull/74) - this way we can test the new actions-based release process