### PR TITLE
Add support for TLS connections to RabbitMQ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased 
+
+- Add support for TLS connections ([#78](https://github.com/alphagov/govuk_message_queue_consumer/pull/78))
+
 # 4.0.0
 
 - Breaking: remove batch consumer ([#73](https://github.com/alphagov/govuk_message_queue_consumer/pull/73))

--- a/README.md
+++ b/README.md
@@ -67,6 +67,22 @@ RABBITMQ_USER=a_user
 RABBITMQ_PASSWORD=a_super_secret
 ```
 
+### TLS Support
+
+There are also some optional environment variables to supply if your RabbitMQ broker requires TLS connections. Amazon MQ requires TLS, but local RabbitMQ and GOV.UK's self-hosted Rabbit MQ EC2 instances do not. For more information, see  ["Connecting to RabbitMQ from Bunny Using TLS/SSL"](https://github.com/ruby-amqp/bunny/blob/main/docs/guides/tls.md#connecting-to-rabbitmq-from-bunny-using-tlsssl) in the Bunny gem documentation.
+
+```
+RABBITMQ_TLS=true|false (default: false)
+
+# if RABBITMQ_TLS is given and not false-y, it will also look for the following optional environment variables:
+RABBITMQ_TLS_CERT=/path/to/cert (default: nil)
+RABBITMQ_TLS_KEY=/path/to/key (default: nil)
+RABBITMQ_TLS_CA_CERTIFICATES=/path/to/ca_cert1,/path/to/ca_cert2 (default: empty)
+RABBITMQ_VERIFY_PEER=true (default: false)
+```
+
+### Processing class
+
 Define a class that will process the messages:
 
 ```ruby

--- a/lib/govuk_message_queue_consumer/rabbitmq_config.rb
+++ b/lib/govuk_message_queue_consumer/rabbitmq_config.rb
@@ -10,7 +10,24 @@ module GovukMessageQueueConsumer
         user: fetch(env, "RABBITMQ_USER"),
         pass: fetch(env, "RABBITMQ_PASSWORD"),
         recover_from_connection_close: true,
-      }
+      }.merge(tls_config(env))
+    end
+
+    def self.tls_config(env)
+      # TLS config is optional - local RabbitMQs won't use TLS,
+      # but Amazon MQ enforces it. So we default to non-TLS.
+      if env.fetch("RABBITMQ_TLS", false)
+        {
+          tls: true,
+          tls_cert: env.fetch("RABBITMQ_TLS_CERT", nil),
+          tls_key: env.fetch("RABBITMQ_TLS_KEY", nil),
+          tls_protocol: env.fetch("RABBITMQ_TLS_VERSION", :TLSv1_2).to_sym,
+          tls_ca_certificates: env.fetch("RABBITMQ_TLS_CA_CERTIFICATES", "").split(","),
+          verify_peer: env.fetch("RABBITMQ_VERIFY_PEER", false),
+        }
+      else
+        {}
+      end
     end
 
     def self.fetch(env, variable_name)

--- a/spec/govuk_message_queue_consumer/rabbit_mq_config_spec.rb
+++ b/spec/govuk_message_queue_consumer/rabbit_mq_config_spec.rb
@@ -17,13 +17,55 @@ RSpec.describe GovukMessageQueueConsumer::RabbitMQConfig do
         "RABBITMQ_PASSWORD" => "my_pass",
       }
 
-      expect(described_class.from_environment(env)).to eql({
+      expect(described_class.from_environment(env)).to include({
         hosts: %w[server-one server-two],
         vhost: "/",
         user: "my_user",
         pass: "my_pass",
         recover_from_connection_close: true,
       })
+    end
+
+    it "defaults to not use TLS" do
+      env = {
+        "RABBITMQ_HOSTS" => "server-one,server-two",
+        "RABBITMQ_VHOST" => "/",
+        "RABBITMQ_USER" => "my_user",
+        "RABBITMQ_PASSWORD" => "my_pass",
+      }
+
+      expect(described_class.from_environment(env).keys).not_to include(:tls)
+    end
+
+    context "when TLS environment variable is true" do
+      let(:env) do
+        {
+          "RABBITMQ_HOSTS" => "server-one,server-two",
+          "RABBITMQ_VHOST" => "/",
+          "RABBITMQ_USER" => "my_user",
+          "RABBITMQ_PASSWORD" => "my_pass",
+          "RABBITMQ_TLS" => "true",
+          "RABBITMQ_TLS_CERT" => "/path/to/cert",
+          "RABBITMQ_TLS_KEY" => "/path/to/key",
+          "RABBITMQ_TLS_CA_CERTIFICATES" => "/path/to/ca_cert1,/path/to/ca_cert2",
+          "RABBITMQ_VERIFY_PEER" => "true",
+        }
+      end
+
+      it "includes the given TLS values" do
+        expect(described_class.from_environment(env)).to include({
+          tls: true,
+          tls_cert: "/path/to/cert",
+          tls_key: "/path/to/key",
+          verify_peer: "true",
+        })
+      end
+
+      it "parses the given CA certificates as an array" do
+        expect(described_class.from_environment(env)).to include({
+          tls_ca_certificates: ["/path/to/ca_cert1", "/path/to/ca_cert2"],
+        })
+      end
     end
   end
 end


### PR DESCRIPTION
This is required by Amazon MQ's RabbitMQ implementations, and therefore a blocker if we ever want to move to Amazon MQ.

The new environment variables are all optional, so nothing should change for existing client configurations. See the README for details.