### PR TITLE
Removed cache clearing service reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ For detailed documentation, check out the [gem documentation on rubydoc.info](ht
 
 This gem is used by:
 
-- [Cache clearing service](https://github.com/alphagov/cache-clearing-service).
 - [Content Data API](https://github.com/alphagov/content-data-api).
 - [Email Alert Service](https://github.com/alphagov/email-alert-service/).
 - [Search API](https://github.com/alphagov/search-api).


### PR DESCRIPTION
Removed cache clearing service reference as the application has been retired.

https://trello.com/c/ENPwB2vT/41-retire-cache-clearing-service

https://trello.com/c/TX9wLihh/101-cache-clearing-app-exists-and-we-dont-think-its-necessary-replacing-cache-clearing-app-only-clears-path-not-query-strings
