### PR TITLE
Fix broken handling of signals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 
-* Drop support for Ruby 2.7.
+- Drop support for Ruby 2.7.
+- Fix ability to handle system signals, and report non-`SIGTERM` errors to `GovukError`
 
 # 4.1.0
 
@@ -36,7 +37,7 @@
 # 3.2.0
 
 - Add batch process capabilities
-- Refactor `process_chain` to `message_consumer` 
+- Refactor `process_chain` to `message_consumer`
 
 # 3.1.0
 

--- a/lib/govuk_message_queue_consumer/consumer.rb
+++ b/lib/govuk_message_queue_consumer/consumer.rb
@@ -44,15 +44,16 @@ module GovukMessageQueueConsumer
         @statsd_client.increment("#{@queue_name}.started")
         message_consumer.process(message)
         @statsd_client.increment("#{@queue_name}.#{message.status}")
-      rescue SignalException => e
-        @logger.error "SignalException in processor: \n\n #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}"
-        exit(1) # Ensure rabbitmq requeues outstanding messages
       rescue StandardError => e
         @statsd_client.increment("#{@queue_name}.uncaught_exception")
         GovukError.notify(e) if defined?(GovukError)
         @logger.error "Uncaught exception in processor: \n\n #{e.class}: #{e.message}\n\n#{e.backtrace.join("\n")}"
         exit(1) # Ensure rabbitmq requeues outstanding messages
       end
+    rescue SignalException => e
+      GovukError.notify(e) if defined?(GovukError) && e.message != "SIGTERM"
+
+      exit
     end
 
   private

--- a/spec/govuk_message_queue_consumer/consumer_spec.rb
+++ b/spec/govuk_message_queue_consumer/consumer_spec.rb
@@ -8,28 +8,23 @@ describe GovukMessageQueueConsumer::Consumer do
   let(:client_processor) { instance_double("Client::Processor") }
 
   describe "#run" do
-    it "doesn't create the queue" do
-      stubs = create_bunny_stubs
-      channel = stubs.channel
+    let(:stubs) { create_bunny_stubs }
+    let(:channel) { stubs.channel }
+    let(:queue) { stubs.queue }
 
+    it "doesn't create the queue" do
       expect(channel).to receive(:queue).with("some-queue", { no_declare: true })
 
       described_class.new(queue_name: "some-queue", processor: client_processor, rabbitmq_connection: stubs.connection, logger: logger).run
     end
 
     it "doesn't bind the queue" do
-      stubs = create_bunny_stubs
-      queue = stubs.queue
-
       expect(queue).not_to receive(:bind)
 
       described_class.new(queue_name: "some-queue", processor: client_processor, rabbitmq_connection: stubs.connection, logger: logger).run
     end
 
     it "calls the heartbeat processor when subscribing to messages" do
-      stubs = create_bunny_stubs
-      queue = stubs.queue
-
       expect(queue).to receive(:subscribe).and_yield(:delivery_info_object, :headers, "payload")
       heartbeat_processor_stub = instance_double(GovukMessageQueueConsumer::HeartbeatProcessor)
       allow(GovukMessageQueueConsumer::HeartbeatProcessor).to receive(:new).and_return(heartbeat_processor_stub)
@@ -37,6 +32,33 @@ describe GovukMessageQueueConsumer::Consumer do
       expect(heartbeat_processor_stub).to receive(:process).with(kind_of(GovukMessageQueueConsumer::Message))
 
       described_class.new(queue_name: "some-queue", processor: client_processor, rabbitmq_connection: stubs.connection, logger: logger).run
+    end
+
+    context "when a SignalException is raised" do
+      before do
+        allow(queue).to receive(:subscribe).and_raise(error)
+      end
+
+      context "and the signal is a SIGTERM" do
+        let(:error) { SignalException.new("SIGTERM") }
+
+        it "gracefully exits" do
+          expect { described_class.new(queue_name: "some-queue", processor: client_processor, rabbitmq_connection: stubs.connection, logger: logger).run }.to raise_error(SystemExit)
+        end
+      end
+
+      context "and the signal is an unexpected one" do
+        let(:error) { SignalException.new("SIGWINCH") }
+
+        before do
+          stub_const("GovukError", double(notify: nil)) # rubocop:disable RSpec/VerifiedDoubles
+        end
+
+        it "gracefully exits after notifying GovukError" do
+          expect(GovukError).to receive(:notify).with(error)
+          expect { described_class.new(queue_name: "some-queue", processor: client_processor, rabbitmq_connection: stubs.connection, logger: logger).run }.to raise_error(SystemExit)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Our tooling both past (Upstart?) and present (Kubernetes) sends a `SIGTERM` signal to notify a process that it should gracefully shut down. At the moment, this library doesn't properly handle this - it does rescue the error, but does so in the wrong place (so it's not actually handled) and indiscriminately exits with a non-zero exit code.

- Ensure `SignalException`s raised in `Bunny::Queue#subscribe` (rather than the block passed to it) are rescued
- Exit cleanly when receiving a `SignalException` (the comment next to `exit(1)` used to say "ensure rabbitmq requeues outstanding messages", but that has nothing to do with the exit code, it happens by default if the message hasn't been acked by then)
- Only report a signal exception when it's not a vanilla `SIGTERM`
- Add test for signal handling

Ideally in the future we might take this further and allow in-flight processing to complete before shutting down.
