### PR TITLE
Release version 5.0.0.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 5.0.0
 
 - BREAKING: remove disused support for statsd. No clients in alphagov use the statsd functionality any more, so this is only theoretically breaking.
 - Allow clients to specify a Bunny worker thread pool size of greater than 1. The default behaviour remains unchanged.

--- a/lib/govuk_message_queue_consumer/version.rb
+++ b/lib/govuk_message_queue_consumer/version.rb
@@ -1,3 +1,3 @@
 module GovukMessageQueueConsumer
-  VERSION = "4.2.0".freeze
+  VERSION = "5.0.0".freeze
 end


### PR DESCRIPTION
This version is only technically a breaking change. In practice there are no breaking changes for any of the clients in alphagov.

This repo is owned by the publishing platform team. Please let us know in #govuk-publishing-platform when you raise any PRs.
