### PR TITLE
Add explicit require where `OpenStruct` is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+- Add explicit require for `ostruct` library to `MockMessage` (previously relied on `ostruct` being
+  required somewhere in consuming code)
+
 # 5.0.0
 
 - BREAKING: remove disused support for statsd. No clients in alphagov use the statsd functionality any more, so this is only theoretically breaking.

--- a/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
+++ b/lib/govuk_message_queue_consumer/test_helpers/mock_message.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 module GovukMessageQueueConsumer
   class MockMessage < Message
     attr_reader :acked, :retried, :discarded, :payload, :header, :delivery_info


### PR DESCRIPTION
`OpenStruct` is used by `MockMessage` to represent a message's headers and delivery information, but the file (or indeed the entire library) does not actually require the `ostruct` library which provides this type.

Many of our projects will somehow transitively require it anyway as it's extensively used in Ruby, so this omission hasn't caused issues so far, but we've encountered a problem on `search-api-v2` now where a completely unrelated dependency was updated and no longer uses `ostruct`, causing tests that use `MockMessage` to fail as the library is no longer loaded.
