### PR TITLE
Add explicit dependency on `ostruct` gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+* Add explicit gem dependency for `ostruct` gem (extracted from stdlib into a gem from Ruby 3.5.0)
+  ([#131](https://github.com/alphagov/govuk_message_queue_consumer/pull/131))
+
 ## 5.0.1
 
 * Add explicit require for `ostruct` library to `MockMessage` (previously relied on `ostruct` being

--- a/govuk_message_queue_consumer.gemspec
+++ b/govuk_message_queue_consumer.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.require_path = "lib"
 
   s.add_dependency "bunny", "~> 2.17"
+  s.add_dependency "ostruct"
 
   s.add_development_dependency "bunny-mock"
   s.add_development_dependency "pry-byebug"


### PR DESCRIPTION
`ostruct` is deprecated from the standard library, and will no longer be implicitly available from Ruby 3.5.0:
https://bugs.ruby-lang.org/issues/20309

This adds an explicit gem dependency so we can continue using it in the future, and to make the deprecation warnings go away in consumers (pun intended) of this gem.