### PR TITLE
Fix typo in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,7 @@ updates:
       test:
         patterns:
           - "bunny-mock"
-          - "rspec",
+          - "rspec"
 
   - package-ecosystem: github-actions
     directory: /


### PR DESCRIPTION
The comma was causing dependabot to fail, as the file was not valid YAML.